### PR TITLE
Adapt to pandas 3.0.0

### DIFF
--- a/sync/schema.py
+++ b/sync/schema.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pandera import Check, Column, DataFrameSchema, Index
+from pandera.pandas import Check, Column, DataFrameSchema, Index
 
 from sync import config
 
@@ -7,7 +7,7 @@ elastic_event_schema = DataFrameSchema(
     {
         "period_id": Column(int, Check(lambda s: s.isin([1, 2]))),
         "utc_timestamp": Column(np.dtype("datetime64[ns]")),
-        "player_id": Column(object),
+        "player_id": Column(str),
         "spadl_type": Column(str, Check(lambda s: s.isin(config.SPADL_TYPES))),
         "success": Column(bool),
         # "offside": Column(bool),
@@ -19,7 +19,7 @@ etsy_event_schema = DataFrameSchema(
     {
         "period_id": Column(int, Check(lambda s: s.isin([1, 2]))),
         "utc_timestamp": Column(np.dtype("datetime64[ns]")),
-        "player_id": Column(object),
+        "player_id": Column(str),
         "spadl_type": Column(str, Check(lambda s: s.isin(config.SPADL_TYPES))),
         "start_x": Column(float, Check(lambda s: (s >= 0) & (s <= config.PITCH_X))),
         "start_y": Column(float, Check(lambda s: (s >= 0) & (s <= config.PITCH_Y))),
@@ -33,7 +33,7 @@ synced_event_schema = DataFrameSchema(
         "period_id": Column(int, Check(lambda s: s.isin([1, 2]))),
         "utc_timestamp": Column(np.dtype("datetime64[ns]")),
         "frame_id": Column(float, Check(lambda s: (s >= 0) & (round(s) == s)), nullable=True),
-        "player_id": Column(object),
+        "player_id": Column(str),
         "spadl_type": Column(str, Check(lambda s: s.isin(config.SPADL_TYPES))),
         "success": Column(bool),
         # "offside": Column(bool),
@@ -47,7 +47,7 @@ tracking_schema = DataFrameSchema(
         "period_id": Column(int, Check(lambda s: s.isin([1, 2]))),
         "timestamp": Column(float),
         "utc_timestamp": Column(np.dtype("datetime64[ns]")),
-        "player_id": Column(object, nullable=True),  # Mandatory for players (not ball)
+        "player_id": Column(str, nullable=True),  # Mandatory for players (not ball)
         "ball": Column(bool),
         "x": Column(float),
         "y": Column(float),


### PR DESCRIPTION
Hi,
due to recent pandas update to `3.0.0`, there is now [dedicated `str` type](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-enhancements-string-dtype) which is meant to replace `object`. I got several errors when I tried to follow `tutorial.ipynb`:

**pandera import warning:**

<img width="1314" height="814" alt="pandera-warning" src="https://github.com/user-attachments/assets/15df6146-cc62-4a3a-b8e2-99888c95a5c7" />

**schema error:**

<img width="1314" height="4231" alt="schema-error" src="https://github.com/user-attachments/assets/26febcb2-db6d-411f-b233-7a468497254d" />


This should fix them :)